### PR TITLE
feat: create transaction zod validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "express-async-errors": "^3.1.1",
         "prisma": "^6.13.0",
         "reflect-metadata": "^0.2.2",
-        "tsyringe": "^4.10.0"
+        "tsyringe": "^4.10.0",
+        "zod": "^4.0.15"
       },
       "devDependencies": {
         "@types/amqplib": "^0.10.7",
@@ -2919,6 +2920,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.15.tgz",
+      "integrity": "sha512-2IVHb9h4Mt6+UXkyMs0XbfICUh1eUrlJJAOupBHUhLRnKkruawyDddYRCs0Eizt900ntIMk9/4RksYl+FgSpcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "express-async-errors": "^3.1.1",
     "prisma": "^6.13.0",
     "reflect-metadata": "^0.2.2",
-    "tsyringe": "^4.10.0"
+    "tsyringe": "^4.10.0",
+    "zod": "^4.0.15"
   },
   "devDependencies": {
     "@types/amqplib": "^0.10.7",

--- a/src/infra/http/routes/Transaction/route.ts
+++ b/src/infra/http/routes/Transaction/route.ts
@@ -4,6 +4,7 @@ import { expressAdaptRoute } from "../../adapters/express";
 import { FindTransactionController } from "../../controllers/Transaction/find-transaction.controller";
 import { ListUserTransactionsController } from "../../controllers/Transaction/list-user-transactions.controller";
 import { container } from "@/infra/config/container";
+import { validateCreateTransaction } from "@/infra/validators/zod/create-transaction.validator";
 
 export const transactionRouter = Router();
 
@@ -17,7 +18,11 @@ const listUserTransactionsController = container.resolve(
   ListUserTransactionsController
 );
 
-transactionRouter.post("/", expressAdaptRoute(createTransactionController));
+transactionRouter.post(
+  "/",
+  validateCreateTransaction,
+  expressAdaptRoute(createTransactionController)
+);
 transactionRouter.get(
   "/user",
   expressAdaptRoute(listUserTransactionsController)

--- a/src/infra/validators/zod/create-transaction.validator.ts
+++ b/src/infra/validators/zod/create-transaction.validator.ts
@@ -1,0 +1,27 @@
+// src/infra/http/validators/create-transaction.validator.ts
+import { z } from "zod";
+import { AppError } from "@/domain/errors/app-error";
+import { NextFunction, Request, Response } from "express";
+export const createTransactionSchema = z.object({
+  receiverUserId: z
+    .string()
+    .nonempty({ message: "ID do usuário é obrigatório" }),
+  amount: z.number().positive({ message: "O valor deve ser positivo" }),
+  description: z.string().min(3, { message: "Descrição muito curta" }),
+});
+
+export function validateCreateTransaction(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  try {
+    req.body = createTransactionSchema.parse(req.body);
+    return next();
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new AppError(error.issues[0].message, 400);
+    }
+    next(error);
+  }
+}


### PR DESCRIPTION

## Descrição

Esta PR implementa a validação dos dados de entrada para a criação de transações no serviço de Transactions, garantindo que os campos enviados na requisição atendam aos critérios esperados antes de chegarem ao caso de uso.

### Alterações principais

- Criação do schema de validação com Zod para o payload de criação de transação, validando campos:
  - `amount` (número positivo)
  - `description` (string com tamanho mínimo)
  - `receiverUserId` (string não vazia, adaptado para aceitar IDs do Cognito)
- Implementação de middleware de validação Express usando o schema Zod
- Integração do middleware na rota de criação de transação, garantindo que requisições inválidas retornem erro 400 com mensagem apropriada
- Manutenção do desacoplamento da lógica de domínio e aplicação em relação à biblioteca Zod, mantendo a validação na camada de infraestrutura

